### PR TITLE
minor fixes for core_fr.properties

### DIFF
--- a/src/main/resources/org/sonar/l10n/core_fr.properties
+++ b/src/main/resources/org/sonar/l10n/core_fr.properties
@@ -969,7 +969,7 @@ update_key.new_key=Nouvelle cl\u00E9
 update_key.key_updated=La cl\u00E9 a \u00E9t\u00E9 mise \u00E0 jour avec succ\u00E8s pour toutes les ressources concern\u00E9es.
 update_key.key_updated.reload=La cl\u00E9 a \u00E9t\u00E9 mise \u00E0 jour avec succ\u00E8s pour toutes les ressources concern\u00E9es. Cette page va se rafra\u00EEchir prochainement. 
 update_key.bulk_change_description=La mise \u00E0 jour de masse permet de remplacer une partie de la cl\u00E9 du projet actuel (ainsi que de ses modules et de ses ressources) par une autre valeur, si cela est possible.
-update_key.current_key_for_project_x_is_x=La cl\u00E9 du projet "{0}" est actuellement "<b>{1}</b>".
+update_key.current_key_for_project_x_is_x=La cl\u00E9 du projet "{0}" est actuellement "{1}".
 update_key.replace=Remplacer
 update_key.by=Par
 update_key.replace_example=Ex. : "org.myCompany"
@@ -2132,12 +2132,12 @@ marketplace.download_package=T\u00E9l\u00E9charger le paquet
 # BACKGROUND TASKS
 #
 #------------------------------------------------------------------------------
-component_navigation.status.failed=La derni\u00E8re analyse a \u00E9chou\u00E9e.
-component_navigation.status.failed.admin=La derni\u00E8re analyse a \u00E9chou\u00E9e.<brPlus de d\u00E9tails sur la page <a href="{0}">Background Tasks</a>.
+component_navigation.status.failed=La derni\u00E8re analyse a \u00E9chou\u00E9.
+component_navigation.status.failed.admin=La derni\u00E8re analyse a \u00E9chou\u00E9. Plus de d\u00E9tails sur la page {url}.
 component_navigation.status.pending=L'analyse est en attente.
-component_navigation.status.pending.admin=Une analyse est en cours.<br>Plus de d\u00E9tails sur la page <a href="{0}">Background Tasks</a>.
+component_navigation.status.pending.admin=Une analyse est en cours. Plus de d\u00E9tails sur la page {url}.
 component_navigation.status.in_progress=L'analyse est en cours.
-component_navigation.status.in_progress.admin=L'analyse est en cours.<br>Plus de d\u00E9tails sur la page <a href="{0}">Background Tasks</a>.
+component_navigation.status.in_progress.admin=L'analyse est en cours. Plus de d\u00E9tails sur la page {url}.
 
 background_task.status.ALL=Toutes
 background_task.status.PENDING=En attente


### PR DESCRIPTION
In SQ 6.7.5, with FR plugin 1.15.1, I've seen an error message displayed like this (including the HTML markup characters, and {0}):

`La dernière analyse a échouée.<brPlus de détails sur la page <a href="{0}">Background Tasks</a>.
`
It looks like the original string in SQ 6.7.5 sources are:

`component_navigation.status.failed.admin=The last analysis has failed. More details available on the {url} page.`

(ie., no HTML markup, and {url} as a place holder for the link)

I've also removed HTML markup from a few other strings which had none in SQ 6.7.5 sources.